### PR TITLE
osp_exportParam - exporting fitting parameters

### DIFF
--- a/libraries/FID-A/processingTools/op_eccKlose.m
+++ b/libraries/FID-A/processingTools/op_eccKlose.m
@@ -20,7 +20,7 @@
 % out    = Water suppressed output following eddy current correction  
 % outw   = Water unsuppressed output following eddy current correction
 
-function [out,outw]=op_eccKlose(in,inw)
+function [out,outw,inph]=op_eccKlose(in,inw)
 if inw.dims.coils~=0 ||  inw.dims.subSpecs~=0 || inw.averages>1
     if inw.subspecs > 1
         inw_A               = op_takesubspec(inw,1);
@@ -30,7 +30,7 @@ if inw.dims.coils~=0 ||  inw.dims.subSpecs~=0 || inw.averages>1
         inw                 = op_concatAverages(inw_A,inw_B);            
     end
     if ~inw.flags.averaged
-        [inw]             = op_rmempty(inw); 
+        [inw]               = op_rmempty(inw); 
         [inw,~,~]           = op_alignAverages(inw,1,'n');  % Align averages
         inw                 = op_averaging(inw);            % Average
     end
@@ -41,7 +41,7 @@ inph=unwrap(angle(inw.fids));
 
 % Now apply the eddy current correction to both the water-suppressed and the
 % water-unsuppressed data:
- out=in;
+out=in;
 if in.te == inw.te   
     out.fids=out.fids.*exp(1i*-inph);
     out.specs=fftshift(fft(out.fids,[],1),1);          

--- a/process/OspreyProcess.m
+++ b/process/OspreyProcess.m
@@ -72,7 +72,7 @@ for kk = 1:MRSCont.nDatasets(1) %Subject loop
                 mm_ll = MRSCont.opts.MultipleSpectra.mm(ll);
                 raw_mm                         = MRSCont.raw_mm{mm_ll,kk};              % Get the kk-th dataset re_mm
                 if raw_mm.averages > 1 && raw_mm.flags.averaged == 0 %re_mm
-                    [raw_mm,fs,phs]               = op_alignAverages(raw_mm, 1, 'n'); %re_mm
+                    [raw_mm,fs,phs]            = op_alignAverages(raw_mm, 1, 'n'); %re_mm
                     raw_mm                     = op_averaging(raw_mm);            % Average re_mm
                 else %re_mm
                     raw_mm.flags.averaged  = 1; %re_mm
@@ -88,7 +88,7 @@ for kk = 1:MRSCont.nDatasets(1) %Subject loop
                     raw_mm.target = {''};
                     raw_mm.specReg{1}.fs              = fs; % save align parameters
                     raw_mm.specReg{1}.phs             = phs; % save align parameters
-                    raw_mm.specReg{1}.weights{1}         = ones(size(phs)); % save align parameters
+                    raw_mm.specReg{1}.weights{1}      = ones(size(phs)); % save align parameters
                     driftPre = 0;
                 end
                 if raw_mm.flags.isMEGA
@@ -160,7 +160,7 @@ for kk = 1:MRSCont.nDatasets(1) %Subject loop
                     raw_w = op_combine_water_subspecs(raw_w);
                 end
                 if ~MRSCont.flags.isMRSI
-                    [raw_w,~]                       = op_eccKlose(raw_w, raw_w);        % Klose eddy current correction
+                    [raw_w,~,inph]              = op_eccKlose(raw_w, raw_w);        % Klose eddy current correction
                 else
                     [raw_w,~]=op_autophase(raw_w,2,2*4.68);
                 end

--- a/utilities/osp_exportParam.m
+++ b/utilities/osp_exportParam.m
@@ -1,0 +1,64 @@
+function osp_exportParam(MRSCont,path)
+=========|=========|=========|=========|=========|=========|=========|=========|
+% osp_exportParam is used to export the fitting parameters for each metabolite
+% and the spectrum as a whole.
+  
+names = {'ph1','gauss','gaussMM','lorentzMetab','lorentzMM','ph0','ecc','fshift'};
+
+for kk = 1 : 102
+    MMdef(kk,1) = FullDefSin.fit.results.metab.fitParams{1, kk}.ph1;
+    MMupd(kk,1) = FullUpdSep.fit.results.metab.fitParams{1, kk}.ph1;
+    MM1G(kk,1)  = FullDefSin.fit.results.metab.fitParams{2, kk}.ph1;
+    MM2G(kk,1)  = FullUpdSep.fit.results.metab.fitParams{2, kk}.ph1;
+    iMM1G(kk,1) = SingleGauss.fit.results.metab.fitParams{1, kk}.ph1;
+    iMM2G(kk,1) = SeparateGauss.fit.results.metab.fitParams{1, kk}.ph1;
+
+    MMdef(kk,2) = FullDefSin.fit.results.metab.fitParams{1, kk}.gaussLB;
+    MMupd(kk,2) = FullUpdSep.fit.results.metab.fitParams{1, kk}.gaussLB;
+    MM1G(kk,2)  = FullDefSin.fit.results.metab.fitParams{2, kk}.gaussLB;
+    MM2G(kk,2)  = FullUpdSep.fit.results.metab.fitParams{2, kk}.gaussLB;
+    iMM1G(kk,2) = SingleGauss.fit.results.metab.fitParams{1, kk}.gaussLB;
+    iMM2G(kk,2) = SeparateGauss.fit.results.metab.fitParams{1, kk}.gaussLB;
+
+    MMdef(kk,3) = 0;
+    MMupd(kk,3) = 0;
+    MM1G(kk,3)  = 0;
+    MM2G(kk,3)  = FullUpdSep.fit.results.metab.fitParams{2, kk}.gaussLBMM;
+    iMM1G(kk,3) = 0;
+    iMM2G(kk,3) = SeparateGauss.fit.results.metab.fitParams{1, kk}.gaussLBMM;
+
+    MMdef(kk,4) = mean(FullDefSin.fit.results.metab.fitParams{1, kk}.lorentzLB(1:18));
+    MMupd(kk,4) = mean(FullUpdSep.fit.results.metab.fitParams{1, kk}.lorentzLB(1:18));
+    MM1G(kk,4)  = mean(FullDefSin.fit.results.metab.fitParams{2, kk}.lorentzLB(1:18));
+    MM2G(kk,4)  = mean(FullUpdSep.fit.results.metab.fitParams{2, kk}.lorentzLB(1:18));
+    iMM1G(kk,4) = mean(SingleGauss.fit.results.metab.fitParams{1, kk}.lorentzLB(1:18));
+    iMM2G(kk,4) = mean(SeparateGauss.fit.results.metab.fitParams{1, kk}.lorentzLB(1:18));
+
+    MMdef(kk,5) = mean(FullDefSin.fit.results.metab.fitParams{1, kk}.lorentzLB(18:end));
+    MMupd(kk,5) = mean(FullUpdSep.fit.results.metab.fitParams{1, kk}.lorentzLB(18:end));
+    MM1G(kk,5)  = mean(FullDefSin.fit.results.metab.fitParams{2, kk}.lorentzLB(18:end));
+    MM2G(kk,5)  = mean(FullUpdSep.fit.results.metab.fitParams{2, kk}.lorentzLB(18:end));
+    iMM1G(kk,5) = mean(SingleGauss.fit.results.metab.fitParams{1, kk}.lorentzLB(18:end));
+    iMM2G(kk,5) = mean(SeparateGauss.fit.results.metab.fitParams{1, kk}.lorentzLB(18:end));
+
+    MMdef(kk,6) = FullDefSin.fit.results.metab.fitParams{1, kk}.ph0;
+    MMupd(kk,6) = FullUpdSep.fit.results.metab.fitParams{1, kk}.ph0;
+    MM1G(kk,6)  = FullDefSin.fit.results.metab.fitParams{2, kk}.ph0;
+    MM2G(kk,6)  = FullUpdSep.fit.results.metab.fitParams{2, kk}.ph0;
+    iMM1G(kk,6) = SingleGauss.fit.results.metab.fitParams{1, kk}.ph0;
+    iMM2G(kk,6) = SeparateGauss.fit.results.metab.fitParams{1, kk}.ph0;
+
+end
+
+csv_paths = fullfile(path,{'def.csv','upd.csv','M_sin.csv','M_sep.csv','iM_sin.csv','iM_sep.csv'})
+
+    
+writetable(array2table(MMdef,'VariableNames',names),csv_paths{1},'Delimiter',','); % Write table with tab delimiter
+writetable(array2table(MMupd,'VariableNames',names),csv_paths{2},'Delimiter',','); % Write table with tab delimiter
+writetable(array2table(MM1G, 'VariableNames',names),csv_paths{3},'Delimiter',','); % Write table with tab delimiter
+writetable(array2table(MM2G, 'VariableNames',names),csv_paths{4},'Delimiter',','); % Write table with tab delimiter
+writetable(array2table(iMM1G,'VariableNames',names),csv_paths{5},'Delimiter',','); % Write table with tab delimiter
+writetable(array2table(iMM2G,'VariableNames',names),csv_paths{6},'Delimiter',','); % Write table with tab delimiter
+
+  
+end

--- a/utilities/osp_exportParam.m
+++ b/utilities/osp_exportParam.m
@@ -4,49 +4,65 @@ function osp_exportParam(MRSCont,path)
 % and the spectrum as a whole.
   
 names = {'ph1','gauss','gaussMM','lorentzMetab','lorentzMM','ph0','ecc','fshift'};
+num_basis_fcns = shape(MRSCont.fit.basisSet{?})
+% Define storage matrix as: [nDatasets,metab_amp,Lorentzians,Gaussians,fshifts,phi0,phi1,SNR,ecc]
+% index_dict stores names/indices
+% 18 + 8 = 26 basis functions
+parameters = zeros(MRSCont.nDatasets(1), 26 * 3 + fshifts + phi0 + phi1 + SNR + ecc)
 
-for kk = 1 : 102
-    MMdef(kk,1) = FullDefSin.fit.results.metab.fitParams{1, kk}.ph1;
-    MMupd(kk,1) = FullUpdSep.fit.results.metab.fitParams{1, kk}.ph1;
-    MM1G(kk,1)  = FullDefSin.fit.results.metab.fitParams{2, kk}.ph1;
-    MM2G(kk,1)  = FullUpdSep.fit.results.metab.fitParams{2, kk}.ph1;
-    iMM1G(kk,1) = SingleGauss.fit.results.metab.fitParams{1, kk}.ph1;
-    iMM2G(kk,1) = SeparateGauss.fit.results.metab.fitParams{1, kk}.ph1;
+for kk = 1:MRSCont.nDatasets(1)
+    parameters(kk,1:26)    = fit.results.metab.fitParams{?, kk}.amp;
+    parameters(kk,27:52)   = fit.results.metab.fitParams{?, kk}.lorentzLB;
+    parameters(kk,53:70)   = fit.results.metab.fitParams{?, kk}.gaussLB;
+    parameters(kk,70:78)   = fit.results.metab.fitParams{?, kk}.gaussLBMM;
+    parameters(kk,79:104)  = fit.results.metab.fitParams{?, kk}.fshifts; % rad2deg()
+    parameters(kk,105)     = fit.results.metab.fitParams{?, kk}.ph0; % rad2deg()
+    parameters(kk,106)     = fit.results.metab.fitParams{?, kk}.ph1; % rad2deg()
+    parameters(kk,107)     = fit.results.metab.fitParams{?, kk}.SNR;
+    parameters(kk,107)     = fit.results.metab.fitParams{?, kk}.SNR;
+    parameters(kk,108)     = fit.results.metab.fitParams{?, kk}.ecc;
+    
+%     MMdef(kk,1) = FullDefSin.fit.results.metab.fitParams{1, kk}.ph1;
+%     MMupd(kk,1) = FullUpdSep.fit.results.metab.fitParams{1, kk}.ph1;
+%     MM1G(kk,1)  = FullDefSin.fit.results.metab.fitParams{2, kk}.ph1;
+%     MM2G(kk,1)  = FullUpdSep.fit.results.metab.fitParams{2, kk}.ph1;
+%     iMM1G(kk,1) = SingleGauss.fit.results.metab.fitParams{1, kk}.ph1;
+%     iMM2G(kk,1) = SeparateGauss.fit.results.metab.fitParams{1, kk}.ph1;
 
-    MMdef(kk,2) = FullDefSin.fit.results.metab.fitParams{1, kk}.gaussLB;
-    MMupd(kk,2) = FullUpdSep.fit.results.metab.fitParams{1, kk}.gaussLB;
-    MM1G(kk,2)  = FullDefSin.fit.results.metab.fitParams{2, kk}.gaussLB;
-    MM2G(kk,2)  = FullUpdSep.fit.results.metab.fitParams{2, kk}.gaussLB;
-    iMM1G(kk,2) = SingleGauss.fit.results.metab.fitParams{1, kk}.gaussLB;
-    iMM2G(kk,2) = SeparateGauss.fit.results.metab.fitParams{1, kk}.gaussLB;
+%     MMdef(kk,2) = FullDefSin.fit.results.metab.fitParams{1, kk}.gaussLB;
+%     MMupd(kk,2) = FullUpdSep.fit.results.metab.fitParams{1, kk}.gaussLB;
+%     MM1G(kk,2)  = FullDefSin.fit.results.metab.fitParams{2, kk}.gaussLB;
+%     MM2G(kk,2)  = FullUpdSep.fit.results.metab.fitParams{2, kk}.gaussLB;
+%     iMM1G(kk,2) = SingleGauss.fit.results.metab.fitParams{1, kk}.gaussLB;
+%     iMM2G(kk,2) = SeparateGauss.fit.results.metab.fitParams{1, kk}.gaussLB;
+    
+%     MMdef(kk,3) = 0;
+%     MMupd(kk,3) = 0;
+%     MM1G(kk,3)  = 0;
+%     MM2G(kk,3)  = FullUpdSep.fit.results.metab.fitParams{2, kk}.gaussLBMM;
+%     iMM1G(kk,3) = 0;
+%     iMM2G(kk,3) = SeparateGauss.fit.results.metab.fitParams{1, kk}.gaussLBMM;
 
-    MMdef(kk,3) = 0;
-    MMupd(kk,3) = 0;
-    MM1G(kk,3)  = 0;
-    MM2G(kk,3)  = FullUpdSep.fit.results.metab.fitParams{2, kk}.gaussLBMM;
-    iMM1G(kk,3) = 0;
-    iMM2G(kk,3) = SeparateGauss.fit.results.metab.fitParams{1, kk}.gaussLBMM;
+%     MMdef(kk,4) = mean(FullDefSin.fit.results.metab.fitParams{1, kk}.lorentzLB(1:18));
+%     MMupd(kk,4) = mean(FullUpdSep.fit.results.metab.fitParams{1, kk}.lorentzLB(1:18));
+%     MM1G(kk,4)  = mean(FullDefSin.fit.results.metab.fitParams{2, kk}.lorentzLB(1:18));
+%     MM2G(kk,4)  = mean(FullUpdSep.fit.results.metab.fitParams{2, kk}.lorentzLB(1:18));
+%     iMM1G(kk,4) = mean(SingleGauss.fit.results.metab.fitParams{1, kk}.lorentzLB(1:18));
+%     iMM2G(kk,4) = mean(SeparateGauss.fit.results.metab.fitParams{1, kk}.lorentzLB(1:18));
 
-    MMdef(kk,4) = mean(FullDefSin.fit.results.metab.fitParams{1, kk}.lorentzLB(1:18));
-    MMupd(kk,4) = mean(FullUpdSep.fit.results.metab.fitParams{1, kk}.lorentzLB(1:18));
-    MM1G(kk,4)  = mean(FullDefSin.fit.results.metab.fitParams{2, kk}.lorentzLB(1:18));
-    MM2G(kk,4)  = mean(FullUpdSep.fit.results.metab.fitParams{2, kk}.lorentzLB(1:18));
-    iMM1G(kk,4) = mean(SingleGauss.fit.results.metab.fitParams{1, kk}.lorentzLB(1:18));
-    iMM2G(kk,4) = mean(SeparateGauss.fit.results.metab.fitParams{1, kk}.lorentzLB(1:18));
+%     MMdef(kk,5) = mean(FullDefSin.fit.results.metab.fitParams{1, kk}.lorentzLB(18:end));
+%     MMupd(kk,5) = mean(FullUpdSep.fit.results.metab.fitParams{1, kk}.lorentzLB(18:end));
+%     MM1G(kk,5)  = mean(FullDefSin.fit.results.metab.fitParams{2, kk}.lorentzLB(18:end));
+%     MM2G(kk,5)  = mean(FullUpdSep.fit.results.metab.fitParams{2, kk}.lorentzLB(18:end));
+%     iMM1G(kk,5) = mean(SingleGauss.fit.results.metab.fitParams{1, kk}.lorentzLB(18:end));
+%     iMM2G(kk,5) = mean(SeparateGauss.fit.results.metab.fitParams{1, kk}.lorentzLB(18:end));
 
-    MMdef(kk,5) = mean(FullDefSin.fit.results.metab.fitParams{1, kk}.lorentzLB(18:end));
-    MMupd(kk,5) = mean(FullUpdSep.fit.results.metab.fitParams{1, kk}.lorentzLB(18:end));
-    MM1G(kk,5)  = mean(FullDefSin.fit.results.metab.fitParams{2, kk}.lorentzLB(18:end));
-    MM2G(kk,5)  = mean(FullUpdSep.fit.results.metab.fitParams{2, kk}.lorentzLB(18:end));
-    iMM1G(kk,5) = mean(SingleGauss.fit.results.metab.fitParams{1, kk}.lorentzLB(18:end));
-    iMM2G(kk,5) = mean(SeparateGauss.fit.results.metab.fitParams{1, kk}.lorentzLB(18:end));
-
-    MMdef(kk,6) = FullDefSin.fit.results.metab.fitParams{1, kk}.ph0;
-    MMupd(kk,6) = FullUpdSep.fit.results.metab.fitParams{1, kk}.ph0;
-    MM1G(kk,6)  = FullDefSin.fit.results.metab.fitParams{2, kk}.ph0;
-    MM2G(kk,6)  = FullUpdSep.fit.results.metab.fitParams{2, kk}.ph0;
-    iMM1G(kk,6) = SingleGauss.fit.results.metab.fitParams{1, kk}.ph0;
-    iMM2G(kk,6) = SeparateGauss.fit.results.metab.fitParams{1, kk}.ph0;
+%     MMdef(kk,6) = FullDefSin.fit.results.metab.fitParams{1, kk}.ph0;
+%     MMupd(kk,6) = FullUpdSep.fit.results.metab.fitParams{1, kk}.ph0;
+%     MM1G(kk,6)  = FullDefSin.fit.results.metab.fitParams{2, kk}.ph0;
+%     MM2G(kk,6)  = FullUpdSep.fit.results.metab.fitParams{2, kk}.ph0;
+%     iMM1G(kk,6) = SingleGauss.fit.results.metab.fitParams{1, kk}.ph0;
+%     iMM2G(kk,6) = SeparateGauss.fit.results.metab.fitParams{1, kk}.ph0;
 
 end
 

--- a/utilities/osp_exportParam.m
+++ b/utilities/osp_exportParam.m
@@ -3,7 +3,7 @@ function osp_exportParam(MRSCont,path)
 % osp_exportParam is used to export the fitting parameters for each metabolite
 % and the spectrum as a whole.
   
-names = {'ph1','gauss','gaussMM','lorentzMetab','lorentzMM','ph0','ecc','fshift'};
+names = {'amplitude','lorentz','gauss','fshift','ph0','ph1','SNR','SNRstd','ecc'};
 num_basis_fcns = shape(MRSCont.fit.basisSet{?})
 % Define storage matrix as: [nDatasets,metab_amp,Lorentzians,Gaussians,fshifts,phi0,phi1,SNR,ecc]
 % index_dict stores names/indices
@@ -19,7 +19,7 @@ for kk = 1:MRSCont.nDatasets(1)
     parameters(kk,105)     = fit.results.metab.fitParams{?, kk}.ph0; % rad2deg()
     parameters(kk,106)     = fit.results.metab.fitParams{?, kk}.ph1; % rad2deg()
     parameters(kk,107)     = fit.results.metab.fitParams{?, kk}.SNR;
-    parameters(kk,107)     = fit.results.metab.fitParams{?, kk}.SNR;
+    parameters(kk,107)     = fit.results.metab.fitParams{?, kk}.SNRstd;
     parameters(kk,108)     = fit.results.metab.fitParams{?, kk}.ecc;
     
 %     MMdef(kk,1) = FullDefSin.fit.results.metab.fitParams{1, kk}.ph1;
@@ -66,15 +66,18 @@ for kk = 1:MRSCont.nDatasets(1)
 
 end
 
-csv_paths = fullfile(path,{'def.csv','upd.csv','M_sin.csv','M_sep.csv','iM_sin.csv','iM_sep.csv'})
+% csv_paths = fullfile(path,{'def.csv','upd.csv','M_sin.csv','M_sep.csv','iM_sin.csv','iM_sep.csv'})
 
     
-writetable(array2table(MMdef,'VariableNames',names),csv_paths{1},'Delimiter',','); % Write table with tab delimiter
-writetable(array2table(MMupd,'VariableNames',names),csv_paths{2},'Delimiter',','); % Write table with tab delimiter
-writetable(array2table(MM1G, 'VariableNames',names),csv_paths{3},'Delimiter',','); % Write table with tab delimiter
-writetable(array2table(MM2G, 'VariableNames',names),csv_paths{4},'Delimiter',','); % Write table with tab delimiter
-writetable(array2table(iMM1G,'VariableNames',names),csv_paths{5},'Delimiter',','); % Write table with tab delimiter
-writetable(array2table(iMM2G,'VariableNames',names),csv_paths{6},'Delimiter',','); % Write table with tab delimiter
+% writetable(array2table(MMdef,'VariableNames',names),csv_paths{1},'Delimiter',','); % Write table with tab delimiter
+% writetable(array2table(MMupd,'VariableNames',names),csv_paths{2},'Delimiter',','); % Write table with tab delimiter
+% writetable(array2table(MM1G, 'VariableNames',names),csv_paths{3},'Delimiter',','); % Write table with tab delimiter
+% writetable(array2table(MM2G, 'VariableNames',names),csv_paths{4},'Delimiter',','); % Write table with tab delimiter
+% writetable(array2table(iMM1G,'VariableNames',names),csv_paths{5},'Delimiter',','); % Write table with tab delimiter
+% writetable(array2table(iMM2G,'VariableNames',names),csv_paths{6},'Delimiter',','); % Write table with tab delimiter
+
+writetable(array2table(parameters, 'VariableNames', names), fullfile(path,'parameters.csv'),'Delimiter',',');
+save(fullfile(path,'parameters.mat'),'names',names,'parameters',parameters','linenames',basisfcn_names)
 
   
 end


### PR DESCRIPTION
op_eccklose now exports inph and that has been updated in OspreyProcess.m. The question now is where to store it in MRSCont. Similarly, the export function (utilities/osp_exportParam.m) has a number of variables but it's not clear where they came from nor what the storage names mean (MMdef, MMupd, MM1G, MM2G, iMM1G, iMM2G).

Another question is for the frequency shifts. There should be one for the entire spectrum, one for MM, and one for each metabolite, correct? It seems that these are done in different functions (and possibly at different stages?). So the questions become: a. does the initial coarse correction affect the final fine correction or is it just a starting point? b. where are these done metabolite by metabolite? and c. again, where should they be saved? MRSCont.fit.results.allFitParams? MRSCont.fit.results.metab.fitParams?

In the fit files, is the entry order of metabList_mm the same as the order of the outputs? Is this already stored in the container or should it be added?

Last question at the moment, is there a list of fitting parameters that get calculated in Osprey? The specific parameters that I need are phi0, phi1, all fshifts, metabolite amplitudes, metabolite+MM-specific lorentzians, global gaussian, SNR plus noise std, and finally header info about vendor, acquisition parameters, and echo time along with the standard fitting outputs. (Regularized baseline values once implemented too.) Are there other variables that Osprey calculates that should be collected too?

All feedback would be greatly appreciated!